### PR TITLE
Fix NRE on language changes (after city is loaded)

### DIFF
--- a/Systems/AssetDescriptionDisplaySystem.cs
+++ b/Systems/AssetDescriptionDisplaySystem.cs
@@ -8,8 +8,8 @@ namespace DetailedDescriptions.Systems
 {
     public partial class AssetDescriptionDisplaySystem : GameSystemBase
     {
-        protected PrefabSystem PrefabSystem;
-        protected LocalizationManager LocalizationManager;
+        protected PrefabSystem PrefabSystem = null!;
+        protected LocalizationManager LocalizationManager = null!;
         protected override void OnCreate()
         {
             base.OnCreate();


### PR DESCRIPTION
### Summary

This update fixes a `NullReferenceException` that could happen when switching languages (after a city is already loaded). It also adds safety checks to handle missing data, and clears the `ZoneLots` size cache to avoid stale data.

---

### What’s Changed
- Fixes `NullReferenceException` triggered when changing to any language after a city has already been loaded
  - Only happens in some saves (not all), and only **after** a city is loaded
  - Does not happen if Options > Interface > Language is changed before loading a city

<!-- blank line here breaks the first list -->
- Adds null-check guards to skip prefabs that are missing or not valid buildings
- Only reads `ZoneType` if `SpawnableBuilding` exists
- Skips empty or invalid zone names  
- Ignores lot sizes that are 0×0 or broken  
- Clears the zone lot size cache before rebuild (prevents leftover data)
- Adds `= null!` to avoid compiler warnings (`CS8618`, these were pre-existing warnings). If warnings are off they could be missed.
- Adds inline comments to clarify changes

### Before vs After

| Case                                       | Before                                      | After (Fixed)                          |
|-------------------------------------------|------------------------------------------------------|----------------------------------------|
| Change language after city is loaded      | `NullReferenceException` in some save cities tested | No errors; safely rebuilds descriptions |
| Missing prefab                            | Unchecked; could throw errors                        | Skipped with null-check guard          |
| Prefab is not a building (no lot size) | Cast to `BuildingPrefab` without checking | Skipped if prefab is not a `BuildingPrefab` (i.e., has lot size data) |
| `ZoneType` access without component       | Assumed present; could fail                         | Only accessed if `SpawnableBuilding` exists (needed for `m_ZoneType`) |
| Rebuilding `ZoneLots`                    | Old data not cleared; could duplicate                 | Cleared on every rebuild               |

